### PR TITLE
I implemented using ^ as ascender in the parser instead of using regex

### DIFF
--- a/javascript/zen_coding.js
+++ b/javascript/zen_coding.js
@@ -992,29 +992,6 @@ var zen_coding = (function(){
 		
 		expandAbbreviation: function(abbr, type, profile) {
 			type = type || 'html';
-			
-			var tokens, _i, _len; // declare variables
-			var token_identifier = '_SVDIUNAUHASDC87ASDJASDH7SADBAMSDNASD_' // pretty long and random string
-			var tokens = [];
-			// replace bracketed sections which which will never contain the ascender (^) with
-			// a token for identifying later
-			var abbr = abbr.replace(/(\[.+?\]|{.+?})/g, function(x) {
-			  tokens.push(x);
-			  return token_identifier;
-			});
-			// replace all the ascender symbols with relevant enclosing brackets
-			abbr = abbr.replace(/[^\^]+(\^+)/g, function(string, hats) {
-			  return string.replace(
-				  new RegExp("([^>]+?(>[^>]+?){" + hats.length + "})\\^+", 'g'),
-				 '($1)+'
-				);
-			});
-			// put all the originally bracketed values back in place of the
-			// token identifiers previously used as placeholders
-			for (_i = 0, _len = tokens.length; _i < _len; _i++) {
-			  abbr = abbr.replace(token_identifier, tokens[_i]);
-			}
-			
 			var parsed_tree = this.parseIntoTree(abbr, type);
 			
 			if (parsed_tree) {

--- a/javascript/zen_parser.js
+++ b/javascript/zen_parser.js
@@ -5,7 +5,8 @@
  * @link http://chikuyonok.ru
  * 
  * @include "zen_coding.js"
- */var zen_parser = (function(){
+ */
+var zen_parser = (function(){
 	
 	var re_valid_name = /^[\w\d\-_\$\:@!]+\+?$/i;
 	
@@ -515,6 +516,14 @@
 						if (!text_lvl && !attr_lvl && i != il - 1 /* expando? */) {
 							dumpToken();
 							context = context.parent.addChild();
+						} else {
+							token += ch;
+						}
+						break;
+					case '^': // Ascension operator
+						if (!text_lvl && !attr_lvl) {
+							dumpToken();
+							context = context.parent.parent.addChild();
 						} else {
 							token += ch;
 						}


### PR DESCRIPTION
Tested for all existing cases mentioned before:

```
div>div>span^^span
div^div
div>span[title="Ability to ascend the DOM tree using ^"]^div
div>span{Ability to ascend the DOM tree using ^}^div
```

And these new case

```
html>head>title^body
html:5>div#first>div.inner^div#second>div.inner
html:5>div>(div>div>div^div)^div*2
html:5>div>div>div^^div
```

Works fine with all of them
