### PR TITLE
html:5 => lang="en_US", but lang="en" is correct

### DIFF
--- a/javascript/zen_settings.js
+++ b/javascript/zen_settings.js
@@ -552,7 +552,7 @@ var zen_settings = {
 					'</html>',
 			
 			'html:5': '<!DOCTYPE HTML>\n' +
-					'<html lang="${locale}">\n' +
+					'<html lang="${lang}">\n' +
 					'<head>\n' +
 					'	<meta charset="${charset}">\n' +
 					'	<title></title>\n' +

--- a/python/zencoding/zen_settings.py
+++ b/python/zencoding/zen_settings.py
@@ -559,7 +559,7 @@ zen_settings = {
 					'</html>',
 			
 			'html:5': '<!DOCTYPE HTML>\n' +
-					'<html lang="${locale}">\n' +
+					'<html lang="${lang}">\n' +
 					'<head>\n' +
 					'	<meta charset="${charset}">\n' +
 					'	<title></title>\n' +


### PR DESCRIPTION
html:5 => lang="en_US", but lang="en" is correct.
I changed code from "locale" to "lang".

---

html:5 "Expand Abbreviation"
&lt;!DOCTYPE HTML&gt;
&lt;html lang=&quot;en_US&quot;&gt;
&lt;head&gt;
    &lt;meta charset=&quot;UTF-8&quot;&gt;
    &lt;title&gt;&lt;/title&gt;
&lt;/head&gt;
&lt;body&gt;

&lt;/body&gt;
&lt;/html&gt;

http://code.google.com/p/zen-coding/issues/detail?id=272
