### PR TITLE
Update overlay.xul

### DIFF
--- a/plugins/komodo/content/overlay.xul
+++ b/plugins/komodo/content/overlay.xul
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <!DOCTYPE overlay PUBLIC "-//MOZILLA//DTD XUL V1.0//EN" "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-<?xml-stylesheet href="chrome://global/skin/global.css" type="text/css"?>
 
 <overlay id="helloworldOverlay"
 	xmlns:html="http://www.w3.org/1999/xhtml"


### PR DESCRIPTION
Minor tweak - don't need to load Komodo's global css rules - as they are already loaded by Komodo itself.
