### PR TITLE
WEB-9563 BEM filter works incorrect with several element names.

### DIFF
--- a/javascript/filters/bem.js
+++ b/javascript/filters/bem.js
@@ -105,16 +105,19 @@ emmet.exec(function(require, _) {
 		// * block__element
 		// * block__element_modifier
 		// * block__element_modifier1_modifier2
+		// * block__element1__element2_modifier1_modifier2
 		// * block_modifier
 		var block = '', element = '', modifier = '';
 		var separators = getSeparators();
 		if (~name.indexOf(separators.element)) {
-			var blockElem = name.split(separators.element);
-			var elemModifiers = blockElem[1].split(separators.modifier);
-			
-			block = blockElem[0];
-			element = elemModifiers.shift();
-			modifier = elemModifiers.join(separators.modifier);
+			var elements = name.split(separators.element);
+			block = elements.shift();
+
+			var modifiers = elements.pop().split(separators.modifier);
+			elements.push(modifiers.shift());
+
+			element = elements.join(separators.element);
+			modifier = modifiers.join(separators.modifier);
 		} else if (~name.indexOf(separators.modifier)) {
 			var blockModifiers = name.split(separators.modifier);
 			

--- a/javascript/unittest/tests/filters.js
+++ b/javascript/unittest/tests/filters.js
@@ -1,4 +1,3 @@
-
 (function() {
 	var actions = emmet.require('actions');
 	
@@ -9,6 +8,19 @@
 	}
 	
 	module('Filters');
+	test('Yandex BEM regression tests (bem)', function () {
+		expand('.name1__name2__name3|bem');
+		equal(editorStub.getContent(), '<div class="name1__name2__name3"></div>');
+
+		expand('.name1__name2__name3_name4_name5|bem');
+		equal(editorStub.getContent(),
+			'<div class="name1__name2__name3 name1__name2__name3_name4_name5"></div>');
+
+		expand('.name1__name2__name3__name4_name5|bem');
+		equal(editorStub.getContent(),
+			'<div class="name1__name2__name3__name4 name1__name2__name3__name4_name5"></div>');
+	});
+
 	test('Yandex BEM2 (bem)', function() {
 		expand('.b_m1._m2|bem');
 		equal(editorStub.getContent(), '<div class="b b_m1 b_m2"></div>');


### PR DESCRIPTION
BEM-filter loses all modifiers and inserts only the first element If class contains several element names.
Now bem-filter able to parse classes with several elements.

See http://youtrack.jetbrains.com/issue/WEB-9563 for details.
