### PR TITLE
Make HTML5 "DOCTYPE" uppercase for XML validity

### DIFF
--- a/snippets.json
+++ b/snippets.json
@@ -628,7 +628,7 @@
 		"filters": "html",
 		"profile": "html",
 		"snippets": {
-			"!!!":    "<!doctype html>",
+			"!!!":    "<!DOCTYPE html>",
 			"!!!4t":  "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">",
 			"!!!4s":  "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\" \"http://www.w3.org/TR/html4/strict.dtd\">",
 			"!!!xt":  "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">",


### PR DESCRIPTION
While the HTML spec states that "DOCTYPE" in HTML5 is case insensitive, it still must be uppercase in XHTML5 for proper XML validation.

Using it in lowercase, then, brings not value over doing so in uppercase, and instead introduces potential problems.
