### PR TITLE
Updating lodash dependency call

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-uglify": "~0.2.4"
   },
   "dependencies": {
-    "lodash": "git://github.com/emmetio/lodash.git",
+    "lodash": "emmetio/lodash.git",
     "requirejs": "~2.1.9"
   }
 }


### PR DESCRIPTION
Setting lodash dependency call to "emmetio/lodash.git" instead of "git://github.com/emmetio/lodash.git" to prevent firewalls' blocking issues.
