### PR TITLE
#346 - Changed expansion of source and src to match the spec

### DIFF
--- a/lib/snippets.json
+++ b/lib/snippets.json
@@ -680,6 +680,7 @@
 			"embed": "<embed src=\"\" type=\"\" />",
 			"object": "<object data=\"\" type=\"\">",
 			"param": "<param name=\"\" value=\"\" />",
+			"source": "<source/>",
 			"map": "<map name=\"\">",
 			"area": "<area shape=\"\" coords=\"\" href=\"\" alt=\"\" />",
 			"area:d": "<area shape=\"default\" href=\"\" alt=\"\" />",


### PR DESCRIPTION
With this change, Emmet correctly transforms `source` and `src` to `<source>` for HTML (or the appropriate variation for XHTML and XML) instead of `<source></source>`. Please see issue #346.