### PR TITLE
#349 - Added abbreviations for srcset, sizes, picture, and related

### DIFF
--- a/lib/snippets.json
+++ b/lib/snippets.json
@@ -676,6 +676,18 @@
 			"script": "<script !src=\"\">",
 			"script:src": "<script src=\"\">",
 			"img": "<img src=\"\" alt=\"\" />",
+			"img:s|img:srcset": "<img srcset=\"\" src=\"\" alt=\"\" />",
+			"img:z|img:sizes": "<img sizes=\"\" srcset=\"\" src=\"\" alt=\"\" />",
+			"picture": "<picture>",
+			"src|source": "<source/>",
+			"src:sc|source:src": "<source src=\"\" type=\"\"/>",
+			"src:s|source:srcset": "<source srcset=\"\"/>",
+			"src:m|source:media": "<source media=\"(${1:min-width: })\" srcset=\"\"/>",
+			"src:t|source:type": "<source srcset=\"|\" type=\"${1:image/}\"/>",
+			"src:z|source:sizes": "<source sizes=\"\" srcset=\"\"/>",
+			"src:mt|source:media:type": "<source media=\"(${1:min-width: })\" srcset=\"\" type=\"${2:image/}\"/>",
+			"src:mz|source:media:sizes": "<source media=\"(${1:min-width: })\" sizes=\"\" srcset=\"\"/>",
+			"src:zt|source:sizes:type": "<source sizes=\"\" srcset=\"\" type=\"${1:image/}\"/>",
 			"iframe": "<iframe src=\"\" frameborder=\"0\">",
 			"embed": "<embed src=\"\" type=\"\" />",
 			"object": "<object data=\"\" type=\"\">",
@@ -736,10 +748,10 @@
 			"bq": "blockquote",
 			"fig": "figure",
 			"figc": "figcaption",
+			"pic": "picture",
 			"ifr": "iframe",
 			"emb": "embed",
 			"obj": "object",
-			"src": "source",
 			"cap": "caption",
 			"colg": "colgroup",
 			"fst": "fieldset",
@@ -767,6 +779,11 @@
 			"doc": "html>(head>meta[charset=${charset}]+title{${1:Document}})+body",
 			"doc4": "html>(head>meta[http-equiv=\"Content-Type\" content=\"text/html;charset=${charset}\"]+title{${1:Document}})+body",
 
+			"ri:d|ri:dpr": "img:s",
+			"ri:v|ri:viewport": "img:z",
+			"ri:a|ri:art": "pic>src:m+img",
+			"ri:t|ri:type": "pic>src:t+img",
+
 			"html:4t":  "!!!4t+doc4[lang=${lang}]",
 			"html:4s":  "!!!4s+doc4[lang=${lang}]",
 			"html:xt":  "!!!xt+doc4[xmlns=http://www.w3.org/1999/xhtml xml:lang=${lang}]",
@@ -784,7 +801,8 @@
 			"tr+": "tr>td",
 			"select+": "select>option",
 			"optgroup+": "optgroup>option",
-			"optg+": "optgroup>option"
+			"optg+": "optgroup>option",
+			"pic+": "picture>source:srcset+img"
 		}
 	},
 	


### PR DESCRIPTION
## About
This pull request addresses issue #349 to make it easier for developers to use `srcset`, `sizes`, `picture` and more for implementing responsive images.

In case you'd like some references handy while considering this update:
- [Responsive images use cases in HTML5.1 Spec](http://www.w3.org/html/wg/drafts/html/master/embedded-content.html#attr-img-srcset)
- [Responsive Images: Use Cases and Documented Code Snippets to Get You Started](https://dev.opera.com/articles/responsive-images/)

## Building Blocks
The following have been added to snippets.json (with the exception of `img`, as noted):

| Abbrev/Alias  | Result  |
| ------------ |---------------|
| `img` *[1]*  | `<img src="" alt="">` |
| `img:srcset` *or* `img:s`  | `<img srcset="" src="" alt="">` |
| `img:sizes` *or* `img:z`   | `<img sizes="" srcset="" src="" alt="">` |
| `picture` *or* `pic` | `<picture></picture>` |
| `source` *or* `src` *[2]*  | `<source>` | 
| `source:srcset` *or* `src:s` | `<source srcset="">` |
| `source:media` *or* `src:m`  | `<source media="(min-width: )" srcset="">` |
| `source:type` *or* `src:t`   | `<source srcset="" type="image/">` |
| `source:sizes` *or* `src:z` | `<source sizes="" srcset="">` |
| `source:media:type` *or* `src:mt` | `<source media="(min-width: )" srcset="" type="image/">` |
| `source:media:sizes` *or* `src:mz` | `<source media="(min-width: )" sizes="" srcset="">` |
| `source:sizes:type` *or* `src:zt` | `<source sizes="" srcset="" type="image/">` |
| `source:src` *or* `src:sc` *[3]* | `<source src="" type="">` |

**Legend**
1 - Unchanged from your current implementation. Here for reference.
2 - Consistent with pull request I submitted for issue #346, but this implementation is slightly different, so this supersedes that pull request.
3 - Used with `audio` and `video`, not for responsive images.

## Other Conveniences
These have been added to snippets.json as well:

(1) `pic+` (an alias for `picture>source:srcset+img`) results in:
```html
<picture>
	<source srcset="">
	<img src="" alt="">
</picture>
```
This also could be achieved with `pic>src:s+img`.

(2) It occurred to me that some coders might prefer to think in terms of the responsive images use cases they want to implement (hence the `ri` prefix shown below). The following shortcuts represent the four basic use cases. (Many others exist, as shown in the Opera article I referenced. They can be fashioned with the building blocks. Having said that, it could be helpful to create `ri` aliases for one or two more of the common ones. I wanted to see if you like the idea of these `ri` aliases at all before doing so.)

1. **Use Case: Device-pixel-ratio-based selection**
 `ri:dpr` *or* `ri:d`  (aliases for `img:s`)

 Result:
 ```html
<img srcset="" src="" alt="">
```

2. **Use Case: Viewport-based selection (to change image size)**
`ri:viewport` *or* `ri:v` (aliases for `img:z`)

 Result:
 ```html
 <img sizes="" srcset="" src="" alt="">
 ```

3. **Use Case: Art direction-based selection**
`ri:art` *or* `ri:a` (aliases for `pic>src:m+img`)

 Result:
 ```html
<picture>
        <source media="(min-width: )" srcset="">
        <img src="" alt="">
</picture>
 ```
 
4. **Use Case: Image type (format)-based selection**
`ri:type` *or* `ri:t` (aliases for `pic>src:t+img`)

 Result:
  ```html
<picture>
        <source srcset="" type="image/">
        <img src="" alt="">
</picture>
 ```

## Notes
- **Order of attributes:** There isn't consensus in the community about a preferred order for the attributes. For example, should it be `<img sizes="" srcset="" src="" alt="">` or `<img src="" alt="" sizes="" srcset="">`? In fact, in the spec and across various tutorials, you'll see `src` and `alt` come first in the device-pixel-ratio-based case, and last in the viewport-based case (I do understand the logic behind that). I suspect the preference will vary from one developer to the next, so some will be happy with how Emmet does it if you decide to merge this PR, while others might want to make local overrides. I'd be happy to change the current order of attributes if you'd like them to be different; for example, to always make `src="" alt=""` come before other attributes on `img`.

- **Putting some attributes on own line:** As you've probably seen, it's popular to make verbose `img` and `picture` tags easier to read by putting some of the attributes and/or their values on their own lines. For example:

 ```html
<picture>
	   <source
		   media="(min-width: 1280px)"
		   sizes="50vw"
		   srcset="opera-fullshot-200.jpg 200w,
				opera-fullshot-400.jpg 400w,
				opera-fullshot-800.jpg 800w,
				opera-fullshot-1200.jpg 1200w">
	   <img
		   src="opera-closeup-400.jpg" alt="The Oslo Opera House"
		   sizes="(min-width: 640px) 60vw, 100vw"
		   srcset="opera-closeup-200.jpg 200w,
				opera-closeup-400.jpg 400w,
				opera-closeup-800.jpg 800w,
				opera-closeup-1200.jpg 1200w">
</picture>
```
 I toyed with doing that, which (as far as I can tell) would have required creating snippets, but I didn't want to go that route without knowing your preference, given there isn't another HTML case where Emmet does that outside of conditional comments. I suppose a flag could be used for toggling between the two modes. I didn't investigate what that would entail, but I believe it would require adjusting the internals some.

* **Providing hints:** I considered including the `w`, `x`, and `vw` unit descriptors in the proper attributes (ex: `sizes="vw"`) under certain conditions as a helpful hint and starter for coders, but omitted them.

* I also thought about putting `"src:sc|source:src": "<source src=\"\" type=\"\"/>",` after the `video` and `audio` definitions because it's related to them, but thought you might want all `src` definitions together, so I put it with the ones related to `picture`.

--

Thank you for considering the update; I know this is a lot to pore through. I also wouldn't be surprised if some of it could be improved via some cleverness in Emmet that I'm unaware of.

I'd be happy to discuss any of this if you'd like. Thanks again.