### PR TITLE
removed duplicate snipopet under css flexbox

### DIFF
--- a/lib/snippets.json
+++ b/lib/snippets.json
@@ -614,7 +614,6 @@
 			"fxw:w": "flex-wrap:wrap;",
 			"fxw:wr": "flex-wrap:wrap-reverse;",
 			"fxf": "flex-flow:|;",
-			"fxf": "flex-flow:|;",
 			"jc": "justify-content:|;",
 			"jc:fs": "justify-content:flex-start;",
 			"jc:fe": "justify-content:flex-end;",


### PR DESCRIPTION
sorry but I left a duplicate snippet in the css flexbox snippets... this removes the duplicate entry