### PR TITLE
fixed bug: 'New line indentation off by one space or tab'

### DIFF
--- a/lib/action/lineBreaks.js
+++ b/lib/action/lineBreaks.js
@@ -46,7 +46,7 @@ define(function(require, exports, module) {
 				var lineRange = editor.getCurrentLineRange();
 				var nextPadding = '';
 					
-				for (var i = lineRange.end + 1, ch; i < len; i++) {
+				for (var i = lineRange.end, ch; i < len; i++) {
 					ch = content.charAt(i);
 					if (ch == ' ' || ch == '\t')
 						nextPadding += ch;


### PR DESCRIPTION
fixed 'New line indentation off by one space or tab'
see https://github.com/emmetio/brackets-emmet/issues/59
Thanks to @Miguel-Rodrigues
