### PR TITLE
Add PostCSS

### DIFF
--- a/lib/resolver/css.js
+++ b/lib/resolver/css.js
@@ -121,7 +121,7 @@ define(function(require, exports, module) {
 			'Defines a symbol that should be placed at the end of CSS property  ' 
 			+ 'when expanding CSS abbreviations in SASS dialect.');
 
-	prefs.define('css.syntaxes', 'css, less, sass, scss, stylus, styl',
+	prefs.define('css.syntaxes', 'css, less, sass, scss, stylus, styl, postcss, pcss',
 			'List of syntaxes that should be treated as CSS dialects.');
 	
 	prefs.define('css.autoInsertVendorPrefixes', true,
@@ -136,6 +136,7 @@ define(function(require, exports, module) {
 	prefs.define('scss.autoInsertVendorPrefixes', false, 'Same as <code>css.autoInsertVendorPrefixes</code> but for SCSS syntax');
 	prefs.define('sass.autoInsertVendorPrefixes', false, 'Same as <code>css.autoInsertVendorPrefixes</code> but for SASS syntax');
 	prefs.define('stylus.autoInsertVendorPrefixes', false, 'Same as <code>css.autoInsertVendorPrefixes</code> but for Stylus syntax');
+	prefs.define('postcss.autoInsertVendorPrefixes', false, 'Same as <code>css.autoInsertVendorPrefixes</code> but for PostCSS syntax');
 	
 	var descTemplate = template('A comma-separated list of CSS properties that may have ' 
 		+ '<code><%= vendor %></code> vendor prefix. This list is used to generate '

--- a/lib/resolver/cssGradient.js
+++ b/lib/resolver/cssGradient.js
@@ -19,7 +19,7 @@ define(function(require, exports, module) {
 	var editorUtils = require('../utils/editor');
 	var linearGradient = require('./gradient/linear');
 
-	var cssSyntaxes = ['css', 'less', 'sass', 'scss', 'stylus', 'styl'];
+	var cssSyntaxes = ['css', 'less', 'sass', 'scss', 'stylus', 'styl', 'postcss', 'pcss'];
 	
 	// XXX define preferences
 	prefs.define('css.gradient.prefixes', 'webkit, moz, o',
@@ -279,7 +279,7 @@ define(function(require, exports, module) {
 	 */
 	function isValidCaretPosition(gradients, caretPos, syntax) {
 		syntax = syntax || 'css';
-		if (syntax == 'css' || syntax == 'less' || syntax == 'scss') {
+		if (syntax == 'css' || syntax == 'less' || syntax == 'scss' || syntax == 'postcss') {
 			return true;
 		}
 

--- a/lib/snippets.json
+++ b/lib/snippets.json
@@ -950,5 +950,13 @@
 
 	"styl": {
 		"extends": "stylus"
+	},
+
+	"postcss": {
+		"extends": "css"
+	},
+
+	"pcss": {
+		"extends": "postcss"
 	}
 }

--- a/lib/utils/action.js
+++ b/lib/utils/action.js
@@ -323,7 +323,7 @@ define(function(require, exports, module) {
 		 * @return {Boolean}
 		 */
 		isSupportedCSS: function(syntax) {
-			return syntax == 'css' || syntax == 'less' || syntax == 'scss';
+			return syntax == 'css' || syntax == 'less' || syntax == 'scss' || syntax == 'postcss';
 		},
 		
 		/**

--- a/test/cssResolver.js
+++ b/test/cssResolver.js
@@ -160,6 +160,10 @@ describe('CSS Resolver', function() {
 		run('trf${0};');
 		assert.equal(editor.getContent(), 'transform: ;');
 
+		editor.setSyntax('postcss');
+		run('trf${0};');
+		assert.equal(editor.getContent(), 'transform: ;');
+
 		editor.setSyntax('css');
 		run('trf${0};');
 		assert.equal(editor.getContent(), '-webkit-transform: ;\n-ms-transform: ;\n-o-transform: ;\ntransform: ;');


### PR DESCRIPTION
I want to add PostCSS support so I can use Emmet in Sublime Text with [PostCSS syntax highlighting](https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS). This syntax file using `scss` scope for now, but I want to switch it to `postcss`. I haven't switched it yet because users of PostCSS syntax haven't possibility to use Emmet. So I want add `postcss` scope support to Emmet first, and then switch syntax file to it.

This PR is needed for another my PR to emmet-sublime: https://github.com/sergeche/emmet-sublime/pull/587.