### PR TITLE
fix #396. Raise error when there is no matching quote.

### DIFF
--- a/lib/parser/css.js
+++ b/lib/parser/css.js
@@ -201,6 +201,8 @@ define(function(require, exports, module) {
 					// end of line with no \ escape = bad
 					raiseError("Unterminated string");
 				}
+			} else if (c === '') {
+				raiseError("Unterminated string");
 			} else {
 				if (c === "\\") {
 					token += c + w.nextChar();


### PR DESCRIPTION
While troubleshooting issue https://github.com/Microsoft/vscode/issues/17166 for VS Code, we found the trigger is running `expandAbbreviation` on a css rule without a closing quote, for example as below

```
.foo { 
  font-family: 'Segoe UI, Tahoma, Geneva, Verdana, sans-serif;
}
```

The root cause is that we don't quit the while loop while parsing quotes. We are handling brackets correctly, here this change is just aligning with other parts.