### PR TITLE
Fixes #491 No expand when css abbr ends with :

### DIFF
--- a/lib/resolver/css.js
+++ b/lib/resolver/css.js
@@ -829,7 +829,7 @@ define(function(require, exports, module) {
 			}
 			
 			if (!snippet) {
-				if (!abbrData.property) {
+				if (!abbrData.property || abbrData.property.endsWith(':')) {
 					return null;
 				}
 				snippet = abbrData.property + ':' + defaultValue;


### PR DESCRIPTION
Fixes the issue of `:;` getting added when css abbr ends with `:`

See #491 or https://github.com/Microsoft/vscode/issues/1623
