### PR TITLE
Fixes #493 CaptureContext should work for jsx as well

### DIFF
--- a/lib/utils/action.js
+++ b/lib/utils/action.js
@@ -160,7 +160,7 @@ define(function(require, exports, module) {
 		 * @returns {Object}
 		 */
 		captureContext: function(editor, pos) {
-			var allowedSyntaxes = {'html': 1, 'xml': 1, 'xsl': 1};
+			var allowedSyntaxes = {'html': 1, 'xml': 1, 'xsl': 1, 'jsx': 1};
 			var syntax = editor.getSyntax();
 			if (syntax in allowedSyntaxes) {
 				var content = editor.getContent();


### PR DESCRIPTION
UpdateTag feature doesn't work for html tags inside a jsx file in VS Code.

Root cause: https://github.com/Microsoft/vscode/issues/20953#issuecomment-290965496

Ideally, this should be done for all syntax that extends `html` syntax as defined https://github.com/emmetio/emmet/blob/master/lib/snippets.json

But I don't have the expertise for any of the other languages other than jsx, therefore adding the fix for jsx