### PR TITLE
ci: test Node.js 6, 8, 10 and latest (11)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
+  - "8"
+  - "10"
+  - "node"


### PR DESCRIPTION
All odd releases are short living and the even releases become LTS.
Node.js 4 already reached its EOL last year.
Let's test against the current LTS releases.

Also see https://github.com/nodejs/Release/blob/master/README.md