### PR TITLE
Add peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
   },
   "homepage": "https://github.com/emmetio/emmet#readme",
   "devDependencies": {
-    "@emmetio/abbreviation": "^2.0.0-rc.2",
-    "@emmetio/css-abbreviation": "^2.0.0-rc.2",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.8",
     "lerna": "^3.16.4",
@@ -37,6 +35,10 @@
     "ts-node": "^8.4.1",
     "tslint": "^5.20.0",
     "typescript": "^3.6.2"
+  },
+  "peerDependencies": {
+    "@emmetio/abbreviation": "^2.0.0-rc.2",
+    "@emmetio/css-abbreviation": "^2.0.0-rc.2"
   },
   "mocha": {
     "require": "ts-node/register",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "homepage": "https://github.com/emmetio/emmet#readme",
   "devDependencies": {
+    "@emmetio/abbreviation": "^2.0.0-rc.2",
+    "@emmetio/css-abbreviation": "^2.0.0-rc.2",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.8",
     "lerna": "^3.16.4",


### PR DESCRIPTION
I was updating `vscode-emmet-helper`, looks package `emmet` depends on 
 `@emmetio/abbreviation` and `@emmetio/css-abbreviation` so I guess they should be peer dependencies. If you feel they should be dependencies instead, I'll modify the PR.

~No wait am I missing something? Are they getting bundled?~
Oh okay looks like they are getting bundled that's why the code works but the TypeScript type definition files requires them...
```
node_modules/emmet/dist/src/index.d.ts:1:50 - error TS2307: Cannot find module '@emmetio/abbreviation'.

1 import markupAbbreviation, { Abbreviation } from '@emmetio/abbreviation';
                                                   ~~~~~~~~~~~~~~~~~~~~~~~
```
What should one do in such case? Adding peerDeps or deps will solve it but then people will have to install it unnecessarily.