### PR TITLE
Allow "." to be a Literal token

### DIFF
--- a/packages/css-abbreviation/src/tokenizer/index.ts
+++ b/packages/css-abbreviation/src/tokenizer/index.ts
@@ -12,8 +12,8 @@ export default function tokenize(abbr: string, isValue?: boolean): AllTokens[] {
 
     while (!scanner.eof()) {
         token = field(scanner)
-            || literal(scanner, brackets === 0 && !isValue)
             || numberValue(scanner)
+            || literal(scanner, brackets === 0 && !isValue)
             || colorValue(scanner)
             || stringValue(scanner)
             || bracket(scanner)
@@ -130,6 +130,8 @@ function literal(scanner: Scanner, short?: boolean): Literal | undefined {
         scanner.eatWhile(short ? isAlphaWord : isKeyword);
     } else if (scanner.eat(Chars.Percent)) {
         scanner.eatWhile(Chars.Percent);
+    } else if (scanner.eat(Chars.Dot)) {
+        scanner.eatWhile(Chars.Dot);
     }
 
     if (start !== scanner.pos) {

--- a/packages/css-abbreviation/test/tokenizer.ts
+++ b/packages/css-abbreviation/test/tokenizer.ts
@@ -1,4 +1,4 @@
-import { deepEqual, throws } from 'assert';
+import { deepEqual } from 'assert';
 import tokenize from '../src/tokenizer';
 
 describe('Tokenizer', () => {
@@ -101,7 +101,6 @@ describe('Tokenizer', () => {
             { type: 'NumberValue', value: 0.1, unit: '', start: 0, end: 2 },
         ]);
 
-        throws(() => tokenize('.foo'), /Unexpected character at 1/);
     });
 
     it('color values', () => {
@@ -266,9 +265,14 @@ describe('Tokenizer', () => {
             { type: 'Operator', operator: '!', start: 6, end: 7 }
         ]);
 
-        deepEqual(tokenize("${2:0}%"), [
+        deepEqual(tokenize('${2:0}%'), [
             { type: 'Field', index: 2, name: '0', start: 0, end: 6 },
             { type: 'Literal', value: '%', start: 6, end: 7 }
+        ]);
+
+        deepEqual(tokenize('.${1:5}'), [
+            { type: 'Literal', value: '.', start: 0, end: 1 },
+            { type: 'Field', index: 1, name: '5', start: 1, end: 7 },
         ]);
     });
 


### PR DESCRIPTION
```
expand("cra", {
  type: "stylesheet",
  snippets: {
    "cra": "color: rgba(${1:0}, ${2:0}, ${3:0}, .${4:5});"
  }
})
/*
Error: Unexpected character at 30
rgba(${1:0}, ${2:0}, ${3:0}, .${4:5})
-----------------------------^
*/
```

"." should be only allowed with numbers, and this PR compromises on that as ".foo" won't throw. But I guess it's okay as restricting "." as decimal or next to a field would be a little tricky. If you think there's a better way to go about this please feel free to reject this PR.

(Trivia: the above snippet is same as the ["c:ra" in extended snippets](https://github.com/emmetio/Emmetoss/blob/a286122c0a1a0a0609e5fc26bfa44592bef5ef4d/snippets.json#L1134))