### PR TITLE
Add alias "input:btn" for "input:button"

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -85,7 +85,7 @@
 	"input:f|input:file": "inp[type=file]",
 	"input:s|input:submit": "input[type=submit value]",
 	"input:i|input:image": "input[type=image src alt]",
-	"input:b|input:button": "input[type=button value]",
+	"input:b|input:btn|input:button": "input[type=button value]",
 	"input:reset": "input:button[type=reset]",
 	"isindex": "isindex/",
 	"select": "select[name=${1} id=${1}]",


### PR DESCRIPTION
Feature: Add alias "input:btn" for "input:button" in addition to existing alias "input:b"

Rationale? Consistency: "btn" is aliased to "button" but "input:btn" does not work.