### PR TITLE
Fix text node showing up twice during wraps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,27 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@emmetio/abbreviation": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.2.0.tgz",
+      "integrity": "sha512-NPGVUmnr7cLj4i6MKS4c8NjuoIIJROrruJl/8nXsp2MdbDRHvtfq25foySvv/NbfqTQm+P9JzVLDD9JxGIpvkQ==",
+      "requires": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "@emmetio/css-abbreviation": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.2.tgz",
+      "integrity": "sha512-CvYTzJltVpLqJaCZ1Qn97LVAKsl2Uwl2fzir1EX/WuMY3xWxgc3BWRCheL6k65km6GyDrLVl6RhrrNb/pxOiAQ==",
+      "requires": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "@emmetio/scanner": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.0.tgz",
+      "integrity": "sha512-8HqW8EVqjnCmWXVpqAOZf+EGESdkR27odcMMMGefgKXtar00SoYNSryGv//TELI4T3QFsECo78p+0lmalk/CFA=="
+    },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",

--- a/packages/abbreviation/test/convert.ts
+++ b/packages/abbreviation/test/convert.ts
@@ -69,6 +69,9 @@ describe('Convert token abbreviations', () => {
         equal(parse('a[href=]', { href: true, text: 'test@domain.com' }), '<a href="mailto:test@domain.com">test@domain.com</a>');
         equal(parse('a[href=]', { href: true, text: 'test here test@domain.com' }), '<a href="">test here test@domain.com</a>');
         equal(parse('a[href=]', { href: true, text: 'test here www.domain.com' }), '<a href="">test here www.domain.com</a>');
+
+        equal(parse('a[href="www.google.it"]', { href: false, text: 'test' }), '<a href="www.google.it">test</a>');
+        equal(parse('a[href="www.example.com"]', { href: true, text: 'www.google.it' }), '<a href="www.example.com">www.google.it</a>');
     });
 
     it('wrap basic', () => {

--- a/src/markup/index.ts
+++ b/src/markup/index.ts
@@ -22,6 +22,7 @@ const formatters: { [syntax: string]: Formatter } = { html, haml, slim, pug };
  * required transformations applied
  */
 export default function parse(abbr: string | Abbreviation, config: Config): Abbreviation {
+    let oldTextValue: string | string[] | undefined;
     if (typeof abbr === 'string') {
         let parseOpt: ParserOptions = config;
         if (config.options['jsx.enabled']) {
@@ -38,6 +39,11 @@ export default function parse(abbr: string | Abbreviation, config: Config): Abbr
         }
 
         abbr = abbreviation(abbr, parseOpt);
+
+        // remove text field before snippets(abbr, config) call
+        // as abbreviation(abbr, parseOpt) already handled it
+        oldTextValue = config.text;
+        config.text = undefined;
     }
 
     // Run abbreviation resolve in two passes:
@@ -46,6 +52,7 @@ export default function parse(abbr: string | Abbreviation, config: Config): Abbr
     // 2. Transform every resolved node
     abbr = snippets(abbr, config);
     walk(abbr, transform, config);
+    config.text = oldTextValue ?? config.text;
     return abbr;
 }
 

--- a/test/expand.ts
+++ b/test/expand.ts
@@ -35,6 +35,11 @@ describe('Expand Abbreviation', () => {
             equal(expand('test[foo]', opt), '<test bar="bar" baz={}></test>');
             equal(expand('test[baz=a foo=1]', opt), '<test foo="1" bar="bar" baz={a}></test>');
 
+            equal(expand('map'), '<map name=""></map>');
+            equal(expand('map[]'), '<map name=""></map>');
+            equal(expand('map[name="valid"]'), '<map name="valid"></map>');
+            equal(expand('map[href="invalid"]'), '<map name="" href="invalid"></map>');
+
             // Apply attributes in reverse order
             equal(expand('test', reverse), '<test bar="bar" baz={}></test>');
             equal(expand('test[foo]', reverse), '<test bar="bar" baz={}></test>');
@@ -101,17 +106,33 @@ describe('Expand Abbreviation', () => {
         it('wrap with abbreviation', () => {
             equal(expand('div>ul', { text: ['<div>line1</div>\n<div>line2</div>'] }),
                 '<div>\n\t<ul>\n\t\t<div>line1</div>\n\t\t<div>line2</div>\n\t</ul>\n</div>');
-            equal(expand('p', { text: 'foo\nbar'}), '<p>\n\tfoo\n\tbar\n</p>');
-            equal(expand('p', { text: '<div>foo</div>'}), '<p>\n\t<div>foo</div>\n</p>');
-            equal(expand('p', { text: '<span>foo</span>'}), '<p><span>foo</span></p>');
-            equal(expand('p', { text: 'foo<span>foo</span>'}), '<p>foo<span>foo</span></p>');
-            equal(expand('p', { text: 'foo<div>foo</div>'}), '<p>foo<div>foo</div></p>');
+            equal(expand('p', { text: 'foo\nbar' }), '<p>\n\tfoo\n\tbar\n</p>');
+            equal(expand('p', { text: '<div>foo</div>' }), '<p>\n\t<div>foo</div>\n</p>');
+            equal(expand('p', { text: '<span>foo</span>' }), '<p><span>foo</span></p>');
+            equal(expand('p', { text: 'foo<span>foo</span>' }), '<p>foo<span>foo</span></p>');
+            equal(expand('p', { text: 'foo<div>foo</div>' }), '<p>foo<div>foo</div></p>');
         });
 
         it('wrap with abbreviation href', () => {
             equal(expand('a', { text: ['www.google.it'] }), '<a href="http://www.google.it">www.google.it</a>');
             equal(expand('a', { text: ['then www.google.it'] }), '<a href="">then www.google.it</a>');
             equal(expand('a', { text: ['www.google.it'], options: { 'markup.href': false } }), '<a href="">www.google.it</a>');
+
+            equal(expand('map[name="https://example.com"]', { text: ['some text'] }),
+                '<map name="https://example.com">some text</map>');
+            equal(expand('map[href="https://example.com"]', { text: ['some text'] }),
+                '<map name="" href="https://example.com">some text</map>');
+            equal(expand('map[name="https://example.com"]>b', { text: ['some text'] }),
+                '<map name="https://example.com"><b>some text</b></map>');
+
+            equal(expand('a[href="https://example.com"]>b', { text: ['<u>some text false</u>'], options: { 'markup.href': false } }),
+                '<a href="https://example.com"><b><u>some text false</u></b></a>');
+            equal(expand('a[href="https://example.com"]>b', { text: ['<u>some text true</u>'], options: { 'markup.href': true } }),
+                '<a href="https://example.com"><b><u>some text true</u></b></a>');
+            equal(expand('a[href="https://example.com"]>div', { text: ['<p>some text false</p>'], options: { 'markup.href': false } }),
+                '<a href="https://example.com">\n\t<div>\n\t\t<p>some text false</p>\n\t</div>\n</a>');
+            equal(expand('a[href="https://example.com"]>div', { text: ['<p>some text true</p>'], options: { 'markup.href': true } }),
+                '<a href="https://example.com">\n\t<div>\n\t\t<p>some text true</p>\n\t</div>\n</a>');
         });
 
         // it.only('debug', () => {


### PR DESCRIPTION
Currently,

Expected:
```ts
equal(expand('map[name="https://example.com"]>b', { text: ['some text'] }),
                '<map name="https://example.com"><b>some text</b></map>');
```

Actual:
`<map name="https://example.com">some text<b>some text</b></map>`.
Notice the duplication of `some text`.

Only the main Emmet package needs to be updated.
The only changes I made in the abbreviation package was adding some tests.