### PR TITLE
add meta:refresh

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -30,6 +30,7 @@
 	"meta:compat": "meta[http-equiv=X-UA-Compatible content='${1:IE=7}']",
 	"meta:edge": "meta:compat[content='${1:ie=edge}']",
 	"meta:redirect": "meta[http-equiv=refresh content='0; url=${1:http://example.com}']",
+	"meta:refresh": "meta[http-equiv=refresh content='${1:5}']",
 	"meta:kw": "meta[name=keywords content]",
 	"meta:desc": "meta[name=description content]",
 	"style": "style",


### PR DESCRIPTION
Like redirect, but without an url, it refreshes the page.
I know that the refresh method is deprecated, but sometimes it still is the easiest way to reload a page when debugging something etc.
https://www.w3schools.com/tags/att_meta_http_equiv.asp
See also my issue #641 a while ago. Unfortunately It seems to have been cut off. But now I got around to make a pull request. Let me know what you think ;)