### PR TITLE
Remove noopener and noreferrer from "a:blank"

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -1,6 +1,6 @@
 {
 	"a": "a[href]",
-	"a:blank": "a[href='http://${0}' target='_blank' rel='noopener noreferrer']",
+	"a:blank": "a[href='http://${0}' target='_blank']",
 	"a:link": "a[href='http://${0}']",
 	"a:mail": "a[href='mailto:${0}']",
 	"a:tel": "a[href='tel:+${0}']",


### PR DESCRIPTION
It used to need a "noopener noreferrer" due to security vulnerabilities, but no longer does.

See: https://github.com/mdn/content/pull/2236