### PR TITLE
remove meta[http-equiv='X-UA-Compatible'] from "doc" snippet

### DIFF
--- a/snippets/html.json
+++ b/snippets/html.json
@@ -145,7 +145,7 @@
 	"ri:t|ri:type": "pic>src:t+img",
 
 	"!!!": "{<!DOCTYPE html>}",
-	"doc": "html[lang=${lang}]>(head>meta[charset=${charset}]+meta[http-equiv='X-UA-Compatible'][content='IE=edge']+meta:vp+title{${1:Document}})+body",
+	"doc": "html[lang=${lang}]>(head>meta[charset=${charset}]+meta:vp+title{${1:Document}})+body",
 	"!|html:5": "!!!+doc",
 
 	"c": "{<!-- ${0} -->}",

--- a/test/expand.ts
+++ b/test/expand.ts
@@ -153,7 +153,7 @@ describe('Expand Abbreviation', () => {
     describe('Pug templates', () => {
         const config = resolveConfig({ syntax: 'pug' });
         it('basic', () => {
-            equal(expand('!', config), 'doctype html\nhtml(lang="en")\n\thead\n\t\tmeta(charset="UTF-8")\n\t\tmeta(http-equiv="X-UA-Compatible", content="IE=edge")\n\t\tmeta(name="viewport", content="width=device-width, initial-scale=1.0")\n\t\ttitle Document\n\tbody ');
+            equal(expand('!', config), 'doctype html\nhtml(lang="en")\n\thead\n\t\tmeta(charset="UTF-8")\n\t\tmeta(name="viewport", content="width=device-width, initial-scale=1.0")\n\t\ttitle Document\n\tbody ');
         });
     });
 });


### PR DESCRIPTION
IE 11 has been EOL for quite some time now. This change removes the obsolete `meta[http-equiv='X-UA-Compatible']` from the HTML "doc" snippet.