### PR TITLE
fix: use .cjs file extensions for CJS versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "emmet",
   "version": "2.4.0",
   "description": "Emmet — the essential toolkit for web-developers",
-  "main": "./dist/emmet.cjs.js",
+  "main": "./dist/emmet.cjs.cjs",
   "module": "./dist/emmet.es.js",
   "types": "./dist/src/index.d.ts",
   "type": "module",
   "exports": {
     "import": "./dist/emmet.es.js",
-    "require": "./dist/emmet.cjs.js"
+    "require": "./dist/emmet.cjs.cjs"
   },
   "scripts": {
     "build": "rollup -c",

--- a/packages/abbreviation/package.json
+++ b/packages/abbreviation/package.json
@@ -2,13 +2,13 @@
   "name": "@emmetio/abbreviation",
   "version": "2.3.0",
   "description": "Emmet standalone abbreviation parser",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {
     "import": "./dist/index.js",
-    "require": "./dist/index.cjs.js"
+    "require": "./dist/index.cjs.cjs"
   },
   "scripts": {
     "test": "mocha",

--- a/packages/abbreviation/rollup.config.js
+++ b/packages/abbreviation/rollup.config.js
@@ -8,7 +8,7 @@ export default {
         format: 'cjs',
         sourcemap: true,
         exports: 'named',
-        file: './dist/index.cjs.js'
+        file: './dist/index.cjs.cjs'
     }, {
         format: 'es',
         sourcemap: true,

--- a/packages/css-abbreviation/package.json
+++ b/packages/css-abbreviation/package.json
@@ -2,13 +2,13 @@
   "name": "@emmetio/css-abbreviation",
   "version": "2.1.5",
   "description": "Parses Emmet CSS abbreviation into AST tree",
-  "main": "./dist/index.cjs.js",
+  "main": "./dist/index.cjs.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
   "exports": {
     "import": "./dist/index.js",
-    "require": "./dist/index.cjs.js"
+    "require": "./dist/index.cjs.cjs"
   },
   "scripts": {
     "test": "mocha",

--- a/packages/css-abbreviation/rollup.config.js
+++ b/packages/css-abbreviation/rollup.config.js
@@ -7,7 +7,7 @@ export default {
     plugins: [typescript()],
     output: [{
         format: 'cjs',
-        file: 'dist/index.cjs.js',
+        file: 'dist/index.cjs.cjs',
         sourcemap: true,
         exports: 'named',
     }, {

--- a/packages/scanner/.gitignore
+++ b/packages/scanner/.gitignore
@@ -1,5 +1,5 @@
 /scanner.js
 /scanner.es.js
-/scanner.cjs.js
+/scanner.cjs.cjs
 /*.d.ts
 /*.map

--- a/packages/scanner/package.json
+++ b/packages/scanner/package.json
@@ -2,13 +2,13 @@
   "name": "@emmetio/scanner",
   "version": "1.0.1",
   "description": "Scans given text character-by-character",
-  "main": "./scanner.cjs.js",
+  "main": "./scanner.cjs.cjs",
   "module": "./scanner.js",
   "types": "./scanner.d.ts",
   "type": "module",
   "exports": {
     "import": "./scanner.js",
-    "require": "./scanner.cjs.js"
+    "require": "./scanner.cjs.cjs"
   },
   "scripts": {
     "test": "mocha",

--- a/packages/scanner/rollup.config.js
+++ b/packages/scanner/rollup.config.js
@@ -7,7 +7,7 @@ export default {
         format: 'cjs',
         exports: 'named',
         sourcemap: true,
-        file: './scanner.cjs.js'
+        file: './scanner.cjs.cjs'
     }, {
         format: 'es',
         sourcemap: true,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default {
         format: 'es',
         sourcemap: true
     }, {
-        file: './dist/emmet.cjs.js',
+        file: './dist/emmet.cjs.cjs',
         format: 'cjs',
         exports: 'named',
         sourcemap: true


### PR DESCRIPTION
Since the latest version moved to `type: 'module'`, every `.js` file in the projects are treated as ESM. CJS versions should use a `.cjs` file extension to enforce treating them as CJS