### PR TITLE
Add button type button snippet

### DIFF
--- a/src/snippets/html.json
+++ b/src/snippets/html.json
@@ -104,6 +104,7 @@
 	"command": "command/",
 	"btn:s|button:s|button:submit" : "button[type=submit]",
 	"btn:r|button:r|button:reset" : "button[type=reset]",
+	"btn:b|button:b|button:button" : "button[type=button]",
 	"btn:d|button:d|button:disabled" : "button[disabled.]",
 	"fst:d|fset:d|fieldset:d|fieldset:disabled" : "fieldset[disabled.]",
 


### PR DESCRIPTION
This snippet was available in the deprecated snippets repository (https://github.com/emmetio/snippets) and probably got lost when it was moved to the emmet monorepo.