### PR TITLE
Added <data> snippet

### DIFF
--- a/src/snippets/html.json
+++ b/src/snippets/html.json
@@ -107,6 +107,7 @@
 	"btn:b|button:b|button:button" : "button[type=button]",
 	"btn:d|button:d|button:disabled" : "button[disabled.]",
 	"fst:d|fset:d|fieldset:d|fieldset:disabled" : "fieldset[disabled.]",
+  "data": "data[value]",
 
 	"bq": "blockquote",
 	"fig": "figure",


### PR DESCRIPTION
Fix for [issue 705](https://github.com/emmetio/emmet/issues/705)

I know Emmet will expand any word but this will include the value prop to the tag

I've added a snippet for the `<data>` tag. [W3 Schools](https://www.w3schools.com/tags/tag_data.asp#:~:text=The%20tag%20is%20used,for%20rendering%20in%20a%20browser.) link on the data tag