### PR TITLE
Add test for new JSX markup attributes

### DIFF
--- a/test/expand.ts
+++ b/test/expand.ts
@@ -120,6 +120,29 @@ describe('Expand Abbreviation', () => {
             equal(expand('..foo', { syntax: 'vue' }), '<div :class="foo"></div>');
         });
 
+        it('overrides attributes with custom config', () => {
+            const attrConfig = {
+                syntax: 'jsx',
+                options: {
+                    'markup.attributes': {
+                        'class': 'className',
+                        'class*': 'classStarName',
+                    }
+                }
+            };
+            equal(expand('.foo', attrConfig), '<div className="foo"></div>');
+            equal(expand('..foo', attrConfig), '<div classStarName={styles.foo}></div>');
+            const prefixConfig = {
+                syntax: 'jsx',
+                options: {
+                    'markup.valuePrefix': {
+                        'class*': 'class'
+                    }
+                }
+            };
+            equal(expand('..foo', prefixConfig), '<div styleName={class.foo}></div>');
+        });
+
         it('wrap with abbreviation', () => {
             equal(expand('div>ul', { text: ['<div>line1</div>\n<div>line2</div>'] }),
                 '<div>\n\t<ul>\n\t\t<div>line1</div>\n\t\t<div>line2</div>\n\t</ul>\n</div>');


### PR DESCRIPTION
I thought one of the keys wasn't working, but then I realized I was typing `*class` instead of `class*`.
On the other hand, I now have this PR that introduces some more tests for the codebase.