### PR TITLE
Add stylesheet to !html abbreviation

### DIFF
--- a/src/snippets/html.json
+++ b/src/snippets/html.json
@@ -149,7 +149,7 @@
 	"ri:t|ri:type": "pic>src:t+img",
 
 	"!!!": "{<!DOCTYPE html>}",
-	"doc": "html[lang=${lang}]>(head>meta[charset=${charset}]+meta:vp+title{${1:Document}})+body",
+	"doc": "html[lang=${lang}]>(head>meta[charset=${charset}]+meta:vp+title{${1:Document}}+link:css)+body",
 	"!|html:5": "!!!+doc",
 
 	"c": "{<!-- ${0} -->}",


### PR DESCRIPTION
Since probably a large part of websites generated with emmet need to link a stylesheet, this adds a default css link to the ! html abbreviation.