### PR TITLE
Bugfix/bbs snippet

### DIFF
--- a/src/snippets/css.json
+++ b/src/snippets/css.json
@@ -65,6 +65,8 @@
   "bdble": "border-block-end",
   "bdis": "border-inline-start",
   "bdie": "border-inline-end",
+  "bbs": "border-block-start",
+  "bbe": "border-block-end",
 	"bfv": "backface-visibility:hidden|visible",
 	"bg": "background:${1:#000}",
 	"bg:n": "background: none",

--- a/src/snippets/variables.json
+++ b/src/snippets/variables.json
@@ -1,7 +1,7 @@
 {
 	"lang": "en",
 	"locale": "en-US",
-	"charset": "utf-8",
+	"charset": "UTF-8",
 	"indentation": "\t",
 	"newline": "\n"
 }

--- a/test/stylesheet.ts
+++ b/test/stylesheet.ts
@@ -262,7 +262,7 @@ describe('Stylesheet abbreviations', () => {
     it('Logical Properties', () => {
 
         equal(expand('bbs'),'border-block-start: ${0};');
-        equal(expand('bbe"'),'border-block-end: "";');
+        equal(expand('bbe'),'border-block-end: ${0};');
         equal(expand('bis'),'border-inline-start: ${0};');
         equal(expand('bie'),'border-inline-end: ${0};');
         equal(expand('bs'),'block-size: ${0};');


### PR DESCRIPTION
This pull request introduces updates to CSS snippets, fixes a test case for logical properties, and adjusts a variable's value for consistency. The changes enhance the accuracy and functionality of the codebase.

### Updates to CSS snippets:

* [`src/snippets/css.json`](diffhunk://#diff-5a5dd0df49b2da7226e2b6a8025cf7340c66614ca5128c2fb26044566edd1f75R68-R69): Added new abbreviations for logical properties (`bbs` for `border-block-start` and `bbe` for `border-block-end`).

### Test case fixes:

* [`test/stylesheet.ts`](diffhunk://#diff-501fcf1bb166fb09740de36bfd28cb67e79f9d1b74bf1a1067991239c1a531acL265-R265): Corrected the expected output for the `bbe` abbreviation in the logical properties test case to ensure proper functionality.

### Variable adjustments:

* [`src/snippets/variables.json`](diffhunk://#diff-cd13ccb60348a16dc1f77ab1b4affc6f798a1c80cb3f270dbe000b6d1997c2c5L4-R4): Changed the value of `charset` from `utf-8` to `UTF-8` for consistency with standard casing conventions.