### PR TITLE
feat: change default URL protocol from http:// to https://

### DIFF
--- a/packages/abbreviation/src/convert.ts
+++ b/packages/abbreviation/src/convert.ts
@@ -302,7 +302,7 @@ function insertHref(node: AbbreviationNode, text: string) {
     if (urlRegex.test(text)) {
         href = text;
         if (!/\w+:/.test(href) && !href.startsWith('//')) {
-            href = `http://${href}`;
+            href = `https://${href}`;
         }
     } else if (emailRegex.test(text)) {
         href = `mailto:${text}`;

--- a/packages/abbreviation/test/convert.ts
+++ b/packages/abbreviation/test/convert.ts
@@ -58,7 +58,7 @@ describe('Convert token abbreviations', () => {
 
     it('href', () => {
         equal(parse('a', { href: true, text: 'https://www.google.it' }), '<a href="https://www.google.it">https://www.google.it</a>');
-        equal(parse('a', { href: true, text: 'www.google.it' }), '<a href="http://www.google.it">www.google.it</a>');
+        equal(parse('a', { href: true, text: 'www.google.it' }), '<a href="https://www.google.it">www.google.it</a>');
         equal(parse('a', { href: true, text: 'google.it' }), '<a href="">google.it</a>');
         equal(parse('a', { href: true, text: 'test here' }), '<a href="">test here</a>');
         equal(parse('a', { href: true, text: 'test@domain.com' }), '<a href="mailto:test@domain.com">test@domain.com</a>');
@@ -66,14 +66,14 @@ describe('Convert token abbreviations', () => {
         equal(parse('a', { href: true, text: 'test here www.domain.com' }), '<a href="">test here www.domain.com</a>');
 
         equal(parse('a[href=]', { href: true, text: 'https://www.google.it' }), '<a href="https://www.google.it">https://www.google.it</a>');
-        equal(parse('a[href=]', { href: true, text: 'www.google.it' }), '<a href="http://www.google.it">www.google.it</a>');
+        equal(parse('a[href=]', { href: true, text: 'www.google.it' }), '<a href="https://www.google.it">www.google.it</a>');
         equal(parse('a[href=]', { href: true, text: 'google.it' }), '<a href="">google.it</a>');
         equal(parse('a[href=]', { href: true, text: 'test here' }), '<a href="">test here</a>');
         equal(parse('a[href=]', { href: true, text: 'test@domain.com' }), '<a href="mailto:test@domain.com">test@domain.com</a>');
         equal(parse('a[href=]', { href: true, text: 'test here test@domain.com' }), '<a href="">test here test@domain.com</a>');
         equal(parse('a[href=]', { href: true, text: 'test here www.domain.com' }), '<a href="">test here www.domain.com</a>');
         equal(parse('a[class=here]', { href: true, text: 'test@domain.com' }), '<a class="here", href="mailto:test@domain.com">test@domain.com</a>');
-        equal(parse('a.here', { href: true, text: 'www.domain.com' }), '<a class="here", href="http://www.domain.com">www.domain.com</a>');
+        equal(parse('a.here', { href: true, text: 'www.domain.com' }), '<a class="here", href="https://www.domain.com">www.domain.com</a>');
         equal(parse('a[class=here]', { href: true, text: 'test here test@domain.com' }), '<a class="here", href="">test here test@domain.com</a>');
         equal(parse('a.here', { href: true, text: 'test here www.domain.com' }), '<a class="here", href="">test here www.domain.com</a>');
 

--- a/src/snippets/html.json
+++ b/src/snippets/html.json
@@ -1,7 +1,7 @@
 {
 	"a": "a[href]",
-	"a:blank": "a[href='http://${0}' target='_blank' rel='noopener noreferrer']",
-	"a:link": "a[href='http://${0}']",
+	"a:blank": "a[href='https://${0}' target='_blank' rel='noopener noreferrer']",
+	"a:link": "a[href='https://${0}']",
 	"a:mail": "a[href='mailto:${0}']",
 	"a:tel": "a[href='tel:+${0}']",
 	"abbr": "abbr[title]",

--- a/test/expand.ts
+++ b/test/expand.ts
@@ -171,7 +171,7 @@ describe('Expand Abbreviation', () => {
         });
 
         it('wrap with abbreviation href', () => {
-            equal(expand('a', { text: ['www.google.it'] }), '<a href="http://www.google.it">www.google.it</a>');
+            equal(expand('a', { text: ['www.google.it'] }), '<a href="https://www.google.it">www.google.it</a>');
             equal(expand('a', { text: ['then www.google.it'] }), '<a href="">then www.google.it</a>');
             equal(expand('a', { text: ['www.google.it'], options: { 'markup.href': false } }), '<a href="">www.google.it</a>');
 


### PR DESCRIPTION
- Updated insertHref function to use https:// instead of http:// for URLs without protocol
- Updated HTML snippets (a:blank, a:link) to use https:// by default
- Updated all related tests to expect https:// protocol
- Addresses modern web standards where most websites use SSL encryption

Fixes the issue where Emmet automatically adds http:// protocol when wrapping URLs with anchor tags, now defaults to the more secure https:// protocol.